### PR TITLE
Suppress JS ERROR as 'assignment to undeclared variable _myDwell'

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,9 +1,8 @@
-
 const LayoutManager = imports.ui.main.layoutManager;
 const Shell = imports.gi.Shell;
 
 const MessageTray = imports.ui.main.messageTray;
-_myDwell = 0;
+let _myDwell = 0;
 
 function init() { }
 

--- a/extension.js
+++ b/extension.js
@@ -1,3 +1,4 @@
+
 const LayoutManager = imports.ui.main.layoutManager;
 const Shell = imports.gi.Shell;
 


### PR DESCRIPTION
syslog always said like a below:
Nov 22 04:56:42 localhost gnome-session[1555]: JS ERROR: !!!   WARNING: 'assignment to undeclared variable _myDwell'

This modification has suppress above JS ERROR.
