### PR TITLE
Add compatability with Gnome 3.12

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.6", "3.8", "3.10"],
+  "shell-version": ["3.6", "3.8", "3.10", "3.12"],
   "uuid": "insensitivetray@tovotu.de",
   "name": "Insensitive Message Tray",
   "description": "Renders the bottom message tray insensitive so that it doesn't show up automatically when the mouse pointer is placed at the bottom edge of the screen.",


### PR DESCRIPTION
The extension works as intended on Gnome 3.12 without any further modification.
